### PR TITLE
support additional live option in pads added to LiveAudioMixer

### DIFF
--- a/lib/membrane_live_audio_mixer.ex
+++ b/lib/membrane_live_audio_mixer.ex
@@ -16,6 +16,13 @@ defmodule Membrane.LiveAudioMixer do
     Audio that will come before the notification will be buffered.
 
   Input pads can have offset - it tells how much timestamps differ from mixer time.
+  Additionally they can include the live? flag, which adjusts the offset to the current mixer time.
+
+  ```elixir
+  get_child(:a_new_input)
+  |> via_in(:input, options: [offset: 0, live?: false])
+  |> child(:livemixer, Membrane.LiveAudioMixer)
+  ```
   """
 
   use Membrane.Filter

--- a/lib/membrane_live_audio_mixer.ex
+++ b/lib/membrane_live_audio_mixer.ex
@@ -16,7 +16,7 @@ defmodule Membrane.LiveAudioMixer do
     Audio that will come before the notification will be buffered.
 
   Input pads can have offset - it tells how much timestamps differ from mixer time.
-  Setting offset to `live` adjusts the offset to the current mixer timer.
+  Setting offset to `:live` adjusts the offset to the current mixer timer.
 
   ```elixir
   get_child(:a_new_input)

--- a/lib/membrane_live_audio_mixer.ex
+++ b/lib/membrane_live_audio_mixer.ex
@@ -16,11 +16,16 @@ defmodule Membrane.LiveAudioMixer do
     Audio that will come before the notification will be buffered.
 
   Input pads can have offset - it tells how much timestamps differ from mixer time.
-  Additionally they can include the live? flag, which adjusts the offset to the current mixer time.
+  Setting offset to `live` adjusts the offset to the current mixer timer.
 
   ```elixir
   get_child(:a_new_input)
-  |> via_in(:input, options: [offset: 0, live?: false])
+
+  # Choose one:
+  |> via_in(:input, options: [offset: 0]) # Identical to not setting the option
+  |> via_in(:input, options: [offset: 1_000])
+  |> via_in(:input, options: [offset: :live])
+
   |> child(:livemixer, Membrane.LiveAudioMixer)
   ```
   """
@@ -96,14 +101,10 @@ defmodule Membrane.LiveAudioMixer do
       when sample_format in [:s8, :s16le, :s16be, :s24le, :s24be, :s32le, :s32be],
     options: [
       offset: [
-        spec: Time.non_neg(),
+        spec: Time.non_neg() | :live,
         default: 0,
-        description: "Offset of the input audio at the pad."
-      ],
-      live?: [
-        spec: boolean(),
-        default: false,
-        description: "If the input pad should be inserted at the current mixing position."
+        description:
+          "Offset of the input audio at the pad. `:live` sets the offset to the current mixing position."
       ]
     ]
 
@@ -194,17 +195,10 @@ defmodule Membrane.LiveAudioMixer do
         context,
         %{live_queue: live_queue, started?: started?} = state
       ) do
-    if context.pads[pad].options.offset > 0 and context.pads[pad].options.live? do
-      Membrane.Logger.warning("""
-      Setting a non-zero offset with live streamed audio leads to stuttering.
-      """)
-    end
-
     offset =
-      if context.pads[pad].options.live? do
-        context.pads[pad].options.offset + live_queue.current_time
-      else
-        context.pads[pad].options.offset
+      case context.pads[pad].options.offset do
+        :live -> live_queue.current_time
+        _ -> context.pads[pad].options.offset
       end
 
     new_live_queue = LiveQueue.add_queue(live_queue, pad_id, offset)


### PR DESCRIPTION
When adding pads/connecting children to a LiveAudioMixer they have no access to the internal state of the live_queue, and can not coordinate their pts with the internal timer of the LiveAudioMixer element.

An example use case would be a LiveAudioMixer mixing audio from sources that get added and removed during the lifetime of the mixing element. 
For these inputs to be in the mixed result directly, their pts must match the internal `state.live_queue.current_time`.

This change adds the `live?` option to added pads, and when set to true, sets the pad offset to `state.live_queue.current_time`.
Also adds a short example on options to the moduledocs.